### PR TITLE
added projectID persistent input on Sender

### DIFF
--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -506,7 +506,7 @@ namespace SpeckleGrasshopper
 
     protected override void RegisterInputParams( GH_Component.GH_InputParamManager pManager )
     {
-      pManager.AddGenericParameter( "ProjectID", "P", "P is for ProjectID!", GH_ParamAccess.item );
+      pManager.AddGenericParameter( "Project", "P", "Optional input for either a Project type (get it from ListMyProject component) or a string for the ProjectId", GH_ParamAccess.tree );
       pManager[ 0 ].Optional = true;
       pManager.AddGenericParameter( "B", "B", "B is for Book", GH_ParamAccess.tree );
       pManager[ 1 ].Optional = true;
@@ -918,10 +918,17 @@ namespace SpeckleGrasshopper
         })
         .ContinueWith(y => 
         {
-          if (project != null && !project.Streams.Contains(Client.StreamId))
+          if (project != null )
           {
+            if(!project.Streams.Contains(Client.StreamId))
+            {
               project.Streams.Add(Client.StreamId);
               Client.ProjectUpdateAsync(project._id, project); 
+            }
+            else
+            {
+              AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Stream is already part of the project!");
+            }
           }
           else if (projectId != "")
           {

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -1021,7 +1021,10 @@ namespace SpeckleGrasshopper
       foreach ( IGH_Param myParam in Params.Input )
       {
         if (count == 0)
+        {
+          count++;
           continue;
+        }
         foreach ( object o in myParam.VolatileData.AllData( false ) )
         {
           data.Add( o );
@@ -1049,10 +1052,14 @@ namespace SpeckleGrasshopper
       List<Layer> layers = new List<Layer>();
       int startIndex = 0;
       int count = 0;
+      int c = 0;
       foreach ( IGH_Param myParam in Params.Input )
       {
-        if (count == 0)
+        if (c == 0)
+        {
+          c++;
           continue;
+        }
 
         Layer myLayer = new Layer(
             myParam.NickName,
@@ -1065,6 +1072,7 @@ namespace SpeckleGrasshopper
         layers.Add( myLayer );
         startIndex += myParam.VolatileDataCount;
         count++;
+        c++;
       }
       return layers;
     }

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -531,7 +531,7 @@ namespace SpeckleGrasshopper
       if (project == null && v is string vs)
         projectId = vs;
       if(project == null && projectId == "")
-        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Ignore Project ID");
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Ignoring Project ID");
 
       if ( Client == null )
       {
@@ -922,6 +922,32 @@ namespace SpeckleGrasshopper
           {
               project.Streams.Add(Client.StreamId);
               Client.ProjectUpdateAsync(project._id, project); 
+          }
+          else if (projectId != "")
+          {
+            Client.ProjectGetAllAsync().ContinueWith
+            ( tsk =>
+            {
+              if(tsk.Result.Success == true)
+              {
+                var projectReceived = tsk.Result.Resources.Where(x => x._id == projectId).FirstOrDefault();
+                if(projectReceived != null)
+                {
+                  if(!projectReceived.Streams.Contains(Client.StreamId))
+                  {
+                    projectReceived.Streams.Add(Client.StreamId);
+                    Client.ProjectUpdateAsync(projectReceived._id, projectReceived);
+                  }
+                  else
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Stream is already part of the project!");
+                }
+                else
+                {
+                  AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "ProjectId didn't match any known projects");
+                }
+              }
+
+            });
           }
         });
 

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading.Tasks;
 using System.Timers;
@@ -39,6 +40,8 @@ namespace SpeckleGrasshopper
     private string BucketName;
     private List<Layer> BucketLayers = new List<Layer>();
     private List<object> BucketObjects = new List<object>();
+    private Project project = null;
+    private string projectId = "";
 
     public string CurrentJobClient = "none";
     public bool SolutionPrepared = false;
@@ -503,7 +506,7 @@ namespace SpeckleGrasshopper
 
     protected override void RegisterInputParams( GH_Component.GH_InputParamManager pManager )
     {
-      pManager.AddGenericParameter( "ProjectID", "P", "P is for ProjectID!", GH_ParamAccess.tree );
+      pManager.AddGenericParameter( "ProjectID", "P", "P is for ProjectID!", GH_ParamAccess.item );
       pManager[ 0 ].Optional = true;
       pManager.AddGenericParameter( "B", "B", "B is for Book", GH_ParamAccess.tree );
       pManager[ 1 ].Optional = true;
@@ -520,6 +523,7 @@ namespace SpeckleGrasshopper
 
     protected override void SolveInstance( IGH_DataAccess DA )
     {
+      DA.GetData(0, ref project);
       if ( Client == null )
       {
         return;
@@ -897,11 +901,23 @@ namespace SpeckleGrasshopper
       baseProps[ "angleTolerance" ] = Rhino.RhinoDoc.ActiveDoc.ModelAngleToleranceRadians;
       updateStream.BaseProperties = baseProps;
 
-      var response = Client.StreamUpdateAsync( Client.StreamId, updateStream ).Result;
+      Client.StreamUpdateAsync(Client.StreamId, updateStream)
+        .ContinueWith(x =>
+        {
+          var response = x.Result;
+          Log += response.Message;
+        })
+        .ContinueWith(y => 
+        {
+          if (project != null && !project.Streams.Contains(Client.StreamId))
+          {
+              project.Streams.Add(Client.StreamId);
+              Client.ProjectUpdateAsync(project._id, project); 
+          }
+        });
 
       Client.BroadcastMessage( "stream", Client.StreamId, new { eventType = "update-global" } );
 
-      Log += response.Message;
       AddRuntimeMessage( GH_RuntimeMessageLevel.Remark, "Data sent at " + DateTime.Now );
       Message = "Data sent\n@" + DateTime.Now.ToString( "hh:mm:ss" );
 
@@ -959,12 +975,16 @@ namespace SpeckleGrasshopper
     public List<object> GetData( )
     {
       List<object> data = new List<dynamic>();
+      int count = 0;
       foreach ( IGH_Param myParam in Params.Input )
       {
+        if (count == 0)
+          continue;
         foreach ( object o in myParam.VolatileData.AllData( false ) )
         {
           data.Add( o );
         }
+        count++;
       }
 
       data = data.Select( obj =>
@@ -989,6 +1009,9 @@ namespace SpeckleGrasshopper
       int count = 0;
       foreach ( IGH_Param myParam in Params.Input )
       {
+        if (count == 0)
+          continue;
+
         Layer myLayer = new Layer(
             myParam.NickName,
             myParam.InstanceGuid.ToString(),

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -503,7 +503,7 @@ namespace SpeckleGrasshopper
 
     protected override void RegisterInputParams( GH_Component.GH_InputParamManager pManager )
     {
-      pManager.AddGenericParameter( "A", "A", "A is for Apple", GH_ParamAccess.tree );
+      pManager.AddGenericParameter( "ProjectID", "P", "P is for ProjectID!", GH_ParamAccess.tree );
       pManager[ 0 ].Optional = true;
       pManager.AddGenericParameter( "B", "B", "B is for Book", GH_ParamAccess.tree );
       pManager[ 1 ].Optional = true;
@@ -1016,7 +1016,7 @@ namespace SpeckleGrasshopper
 
     bool IGH_VariableParameterComponent.CanInsertParameter( GH_ParameterSide side, int index )
     {
-      if ( side == GH_ParameterSide.Input )
+      if ( side == GH_ParameterSide.Input && index != 0 )
       {
         return true;
       }
@@ -1029,7 +1029,7 @@ namespace SpeckleGrasshopper
     bool IGH_VariableParameterComponent.CanRemoveParameter( GH_ParameterSide side, int index )
     {
       //We can only remove from the input
-      if ( side == GH_ParameterSide.Input && Params.Input.Count > 1 )
+      if ( side == GH_ParameterSide.Input && Params.Input.Count > 1 && index != 0)
       {
         return true;
       }

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -507,12 +507,13 @@ namespace SpeckleGrasshopper
     protected override void RegisterInputParams( GH_Component.GH_InputParamManager pManager )
     {
       pManager.AddGenericParameter( "Project", "P", "Optional input for either a Project type (get it from ListMyProject component) or a string for the ProjectId", GH_ParamAccess.tree );
-      pManager[ 0 ].Optional = true;
+      pManager[0].Optional = true;
+      pManager.AddGenericParameter("A", "A", "A is for Apple", GH_ParamAccess.tree);
+      pManager[1].Optional = true;
       pManager.AddGenericParameter( "B", "B", "B is for Book", GH_ParamAccess.tree );
-      pManager[ 1 ].Optional = true;
+      pManager[2].Optional = true;
       pManager.AddGenericParameter( "C", "C", "C is for Car", GH_ParamAccess.tree );
-      pManager[ 2 ].Optional = true;
-
+      pManager[3].Optional = true;
     }
 
     protected override void RegisterOutputParams( GH_Component.GH_OutputParamManager pManager )

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -523,7 +523,16 @@ namespace SpeckleGrasshopper
 
     protected override void SolveInstance( IGH_DataAccess DA )
     {
-      DA.GetData(0, ref project);
+      project = null;
+      projectId = "";
+      var p = Params.Input[0].VolatileData.AllData(false).FirstOrDefault();
+      var v = p?.GetType().GetProperty("Value").GetValue(p);
+      project = v as Project;
+      if (project == null && v is string vs)
+        projectId = vs;
+      if(project == null && projectId == "")
+        AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Ignore Project ID");
+
       if ( Client == null )
       {
         return;


### PR DESCRIPTION
Added a new persistent input on dataSender component to associate the current stream with a projectID.

- This works for the *FIRST* input you put on the projectID
- It works if you provide a) a Project type or b) a Project id
- It will add remarks / warnings based on whether the inputs were valid. No input or invalid type will be a warning, Non existing id will be a warning. If stream is already part of the project you will get a remark!
- This is working strictly for the default way of sending data and not the "Remote".
