### PR TITLE
Stam/comp reorg sp

### DIFF
--- a/SpeckleGrasshopper/BaseComponents/GhReceiverCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhReceiverCoreClient.cs
@@ -50,9 +50,9 @@ namespace SpeckleGrasshopper
     System.Timers.Timer StreamIdChanger;
 
     public bool IsUpdating = false;
-
+    public override GH_Exposure Exposure => GH_Exposure.primary;
     public GhReceiverClient( )
-      : base("\u200B\u200B\u200B\u200B\u200BData Receiver", "DR",
+      : base("Data Receiver", "DR",
           "Receives data from Speckle.",
           "Speckle", "   Server" )
     {

--- a/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
+++ b/SpeckleGrasshopper/BaseComponents/GhSenderCoreClient.cs
@@ -60,9 +60,9 @@ namespace SpeckleGrasshopper
     public bool ManualMode = false, DebouncingDisabled = false;
 
     public string State;
-
+    public override GH_Exposure Exposure => GH_Exposure.primary;
     public GhSenderClient( )
-      : base("\u200B\u200B\u200B\u200BData Sender", "DS",
+      : base("Data Sender", "DS",
           "Sends data to Speckle.",
           "Speckle", "   Server" )
     {

--- a/SpeckleGrasshopper/Management/AddStreamsToProject.cs
+++ b/SpeckleGrasshopper/Management/AddStreamsToProject.cs
@@ -10,20 +10,20 @@ namespace SpeckleGrasshopper.Management
 {
   public class AddStreamsToProject : GH_Component
   {
-    /// <summary>
-    /// Initializes a new instance of the AddStreamsToProject class.
-    /// </summary>
-
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
     SpeckleApiClient Client = new SpeckleApiClient();
     Action ExpireComponent;
     List<string> AddedStreamIds = new List<string>();
+
+    /// <summary>
+    /// Initializes a new instance of the AddStreamsToProject class.
+    /// </summary>
     public AddStreamsToProject()
       : base("AddStreamsToProject", "Add Streams","Add a list of streams to a project","Speckle", "Management")
     {
 
     }
 
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
 
 
     public override void AddedToDocument(GH_Document document)

--- a/SpeckleGrasshopper/Management/ListMyAccounts.cs
+++ b/SpeckleGrasshopper/Management/ListMyAccounts.cs
@@ -21,8 +21,9 @@ namespace SpeckleGrasshopper.Management
     List<Account> Accounts = new List<Account>();
     Account Selected;
     Action ExpireComponent;
+    public override GH_Exposure Exposure => GH_Exposure.secondary;
 
-    public ListMyAccounts( ) : base("\u200B\u200B\u200BAccounts", "Accounts", "Lists your existing Speckle accounts.", "Speckle", "   Server" )
+    public ListMyAccounts( ) : base("Accounts", "Accounts", "Lists your existing Speckle accounts.", "Speckle", "   Server" )
     {
       SpeckleCore.SpeckleInitializer.Initialize();
       SpeckleCore.LocalContext.Init();

--- a/SpeckleGrasshopper/Management/ListMyProjects.cs
+++ b/SpeckleGrasshopper/Management/ListMyProjects.cs
@@ -18,9 +18,9 @@ namespace SpeckleGrasshopper.Management
     SpeckleApiClient Client = new SpeckleApiClient();
     Project SelectedProject = null;
     Action ExpireComponent;
-
+    public override GH_Exposure Exposure => GH_Exposure.secondary;
     public ListMyProjects()
-      : base("\u200B\u200BProjects", "Projects", "Lists projects you own or have access to", "Speckle", "   Server")
+      : base("Projects", "Projects", "Lists projects you own or have access to", "Speckle", "   Server")
     {
       SpeckleInitializer.Initialize();
       LocalContext.Init();

--- a/SpeckleGrasshopper/Management/ListMyStreams.cs
+++ b/SpeckleGrasshopper/Management/ListMyStreams.cs
@@ -21,8 +21,8 @@ namespace SpeckleGrasshopper.Management
     private bool IncludeHistory;
 
     Action ExpireComponent;
-
-    public ListStreams() : base("\u200BStreams", "Streams", "Lists your existing Speckle streams for a specified account.", "Speckle", "   Server")
+    public override GH_Exposure Exposure => GH_Exposure.tertiary;
+    public ListStreams() : base("Streams", "Streams", "Lists your existing Speckle streams for a specified account.", "Speckle", "   Server")
     {
       SpeckleCore.SpeckleInitializer.Initialize();
       SpeckleCore.LocalContext.Init();

--- a/SpeckleGrasshopper/ObjectCreation/ConvertSpeckleObject.cs
+++ b/SpeckleGrasshopper/ObjectCreation/ConvertSpeckleObject.cs
@@ -21,6 +21,7 @@ namespace SpeckleGrasshopper
 {
   public class ConvertSpeckleObject : GH_Component
   {
+    public override GH_Exposure Exposure => GH_Exposure.hidden;
     private Type SelectedType;
 
     public ConvertSpeckleObject()
@@ -32,7 +33,6 @@ namespace SpeckleGrasshopper
       SpeckleCore.LocalContext.Init();
       SelectedType = null;
     }
-    public override GH_Exposure Exposure => GH_Exposure.hidden;
 
 
     /// <summary>

--- a/SpeckleGrasshopper/ObjectCreation/ModifySpeckleObjectProperties.cs
+++ b/SpeckleGrasshopper/ObjectCreation/ModifySpeckleObjectProperties.cs
@@ -32,7 +32,7 @@ namespace SpeckleGrasshopper
     public bool CheckItAll = false;
 
     public ModifySpeckleObjectProperties( )
-      : base("\u200B\u200B\u200B\u200BModifies Properties", "MP",
+      : base("Modifies Properties", "MP",
         "Allows properties of a SpeckleObject to be modified.",
         "Speckle", " Properties")
     {

--- a/SpeckleGrasshopper/UserDataUtils/CreateUserData.cs
+++ b/SpeckleGrasshopper/UserDataUtils/CreateUserData.cs
@@ -14,13 +14,13 @@ namespace SpeckleGrasshopper
 {
   public class CreateUserData : GH_Component, IGH_VariableParameterComponent
   {
-
+    public override GH_Exposure Exposure => GH_Exposure.secondary;
     private Timer Debouncer;
     /// <summary>
     /// Initializes a new instance of the CreateUserData class.
     /// </summary>
     public CreateUserData( )
-      : base("\u200B\u200B\u200BCreate Properties by Key", "CPK",
+      : base("Create Properties by Key", "CPK",
           "Creates Speckle Object properties by assigning values to keys (input parameters).\nZoom into the component to add more keys.",
           "Speckle", " Properties")
     {

--- a/SpeckleGrasshopper/UserDataUtils/QuerySpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/QuerySpeckleObjectComponent.cs
@@ -12,7 +12,7 @@ namespace SpeckleGrasshopper
     /// Initializes a new instance of the MyComponent1 class.
     /// </summary>
     public QuerySpeckleObjectComponent()
-      : base("\u200B\u200B\u200B\u200B\u200BQuery Properties", "QP",
+      : base("\u200BQuery Properties", "QP",
           "Gets a value from a Speckle Object by string of concatenated keys. \n For example, 'ApplicationId'," +
           " 'Properties.parameters.Description', or 'Properites.structural.propertyRef'",
           "Speckle", " Properties")

--- a/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
@@ -12,11 +12,12 @@ namespace SpeckleGrasshopper.UserDataUtils
 {
   public class SetUserDataSpeckleObjectComponent : GH_Component
   {
+    public override GH_Exposure Exposure => GH_Exposure.secondary;
     /// <summary>
     /// Initializes a new instance of the SetUserDataSpeckleObjectComponent class.
     /// </summary>
     public SetUserDataSpeckleObjectComponent()
-      : base("\u200BSet Properties", "SP",
+      : base("Set Properties", "SP",
           "Add properties to a Speckle Object. Be careful - if a property with the same name already exists, it will be overwritten.",
           "Speckle", " Properties")
     {


### PR DESCRIPTION
So I made the changes here if you want to have a look.

It is not possible to remove all the symbols, unless we are alright with some reordering. But this take cared lots.

I was also looking for a solution regarding the spaces in front of the category names i.e. "    Server" but couldn't find anything like GH_Exposure. A straightforward way to do it, that I've seen other do, is to use number. We can have "0 - Server", "1 - Create" etc...

