### PR TITLE
SBC now finds ApplicationIds for lists inputs ending in Refs

### DIFF
--- a/SpeckleGrasshopper/ObjectCreation/SchemaBuilderComponent.cs
+++ b/SpeckleGrasshopper/ObjectCreation/SchemaBuilderComponent.cs
@@ -325,6 +325,16 @@ namespace SpeckleGrasshopper.UserDataUtils
               innerVal = item;
             }
 
+            if (Params.Input[i].Name.EndsWith("Refs") )
+            {
+              if (innerVal is SpeckleCore.SpeckleObject speckleObject)
+              {
+                string key = "ApplicationId";
+
+                innerVal = speckleObject.GetType().GetProperty(key).GetValue(speckleObject, null);
+              }
+            }
+
             listForSetting.Add(innerVal);
           }
 

--- a/SpeckleGrasshopper/Properties/AssemblyInfo.cs
+++ b/SpeckleGrasshopper/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Rhino.PlugIns;
+using Grasshopper.Kernel;
 
 
 [assembly: PlugInDescription( DescriptionType.Email, "hello@speckle.works" )]
@@ -19,6 +20,9 @@ using Rhino.PlugIns;
 [assembly: AssemblyCopyright("Copyright Speckle.Works & Community Contributors © 2016-2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+// Force directly loading because some SpeckleKit elements do not appear if we load via COFF byte arrays
+[assembly: GH_Loading(GH_LoadingDemand.ForceDirect)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
This extends the work from #4 to also work for list inputs whose names end in `Refs` (plural)