### PR TITLE
phpy conflicts

### DIFF
--- a/SpeckleGrasshopper/Parameters/Param_SpeckleStreams.cs
+++ b/SpeckleGrasshopper/Parameters/Param_SpeckleStreams.cs
@@ -37,6 +37,11 @@ namespace SpeckleGrasshopper.Parameters
   public class GH_SpeckleStream : GH_Goo<SpeckleStream>
   {
 
+    public GH_SpeckleStream()
+    {
+      Value = null;
+    }
+
     public GH_SpeckleStream(SpeckleStream speckleStream)
     {
       Value = speckleStream;


### PR DESCRIPTION
When a phpy library exists along with Speckle, there is an error GUI that comes up while loading grasshopper. This is not breaking the plugin but it is annoying and detrimental for running this in RhinoCompute.

This small fix just adds a new constructor for ```GH_SpeckleStream``` class. More details about it [here](https://discourse.mcneel.com/t/weird-error-instantiatet-cannot-be-called-if-t-is-an-abstract-type/95680/19?u=psarras_st)