### PR TITLE
Add hash recalc to capture prop changes for Set Properties component

### DIFF
--- a/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
+++ b/SpeckleGrasshopper/UserDataUtils/SetUserDataSpeckleObjectComponent.cs
@@ -87,7 +87,7 @@ namespace SpeckleGrasshopper.UserDataUtils
         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Input object is not a dictionary. (IDictionary<string, object>)");
       }
 
-
+      speckleObject.GenerateHash();
       DA.SetData(0, speckleObject);
     }
 


### PR DESCRIPTION
Object hashes are not currently recalculated after obj properties are set/changed using the Set Properties component. As such, an object with changed custom properties does not "seen" as a changed object and therefore does not get updated on the server.